### PR TITLE
include request context in order to satisfy sekizai

### DIFF
--- a/shop_paypal/offsite_paypal.py
+++ b/shop_paypal/offsite_paypal.py
@@ -91,7 +91,8 @@ class OffsitePaypalBackend(object):
 
     @csrf_exempt
     def paypal_successful_return_view(self, request):
-        return render_to_response("shop_paypal/success.html", {})
+        rc = RequestContext(request, {})
+        return render_to_response("shop_paypal/success.html", rc)
 
     #===========================================================================
     # Signal listeners


### PR DESCRIPTION
success view includes request context in order to satisfy sekizai when shop is used in djangocms. without this, templates used for 'paypal_success' will fail when they extend from templates that load sekizai tags.
