### PR TITLE
Set backend_verbose_name

### DIFF
--- a/shop_paypal/offsite_paypal.py
+++ b/shop_paypal/offsite_paypal.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.views.decorators.csrf import csrf_exempt
+from django.utils.translation import ugettext_lazy as _
 
 from paypal.standard.forms import PayPalPaymentsForm
 from paypal.standard.ipn.signals import payment_was_successful as success_signal
@@ -24,6 +25,7 @@ class OffsitePaypalBackend(object):
     '''
 
     backend_name = "Paypal"
+    backend_verbose_name = _("Paypal")
     url_namespace = "paypal"
 
     #===========================================================================


### PR DESCRIPTION
Also mark it for translation. This allows people to use the i18n infrastructure to determine the name that is displayed in frontend code front for this backend.

Sorry, no tests -- but maybe this is trivial enough to merge anyway?
