### PR TITLE
Enabled inclusion of templates when using pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,4 @@
 include AUTHORS.rst
 include LICENSE.rst
-include CHANGELOG.rst
 include README.rst
-include runtests.sh
-recursive-include docs *
-recursive-include shop_paypal/locale *
 recursive-include shop_paypal/templates *

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setup(
         'django-paypal',
     ],
     packages=find_packages(exclude=["example", "example.*"]),
-    zip_safe=False
+    zip_safe=False,
+    include_package_data=True,
 )


### PR DESCRIPTION
Hi Chris,

The templates directory wasn't being included when installing via pip install, I've adjusted it so now it does.

I removed a couple of lines from the manifest because pip was complaining about not finding those files.

David
